### PR TITLE
Fix: filter null metric values that break Prometheus (#55)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ exports.expressCreateServer = (hookName, args, cb) => {
     let response = '';
     const flattened = flatten(stats.toJSON());
     for (const [dirtyKey, value] of Object.entries(flattened)) {
-      if (!isNaN(value)) {
+      if (value != null && !isNaN(value)) {
         const key = dirtyKey.replace(/[^a-zA-Z0-9_]/g, '_');
         response += `# HELP ${key} Some Etherpad related data\n`;
         response += `# TYPE ${key} gauge\n`;


### PR DESCRIPTION
Fixes #55 — `isNaN(null)` returns false (null coerces to 0), so null values were output as `key null` which Prometheus can't parse. Added null check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)